### PR TITLE
feat: Reuse existing message for training select menu

### DIFF
--- a/apps/bot-discord/src/utils/trainAISelectMenu.js
+++ b/apps/bot-discord/src/utils/trainAISelectMenu.js
@@ -58,7 +58,7 @@ export default async function trainAISelectMenu(
 	const voteId = interaction.targetMessage ? interaction.targetMessage.id :
 		interaction.message.reference.messageId;
 	collector.on('collect', (i) => {
-		i.reply({ content: 'Sent training data to server.', ephemeral: true });
+		i.message.edit({ content: 'Sent training data to server.', components: [] });
 
 		const existingVote = interaction.client.trainingVotes.get(voteId);
 		if (existingVote) clearTimeout(existingVote);


### PR DESCRIPTION
In the current state, here is how it looks when training the bot:
![image](https://github.com/ReVanced/revanced-helper/assets/45696571/def65352-2221-4a3f-bdee-8f3563521262)
This PR aims to fix it to make it looks like this instead:
![image](https://github.com/ReVanced/revanced-helper/assets/45696571/8cb021b4-08de-473b-89c3-6dc03ad75516)
